### PR TITLE
hotfix: use generateContentHistory

### DIFF
--- a/src/intelligence/intelligence.service.ts
+++ b/src/intelligence/intelligence.service.ts
@@ -378,7 +378,7 @@ Example Matching:
       data: {
         chatId: chatId,
         content: result.content,
-        role: 'assistant',
+        role: 'model',
       },
     });
 
@@ -461,7 +461,7 @@ Example Matching:
         data: {
           chatId,
           content: fullResponse,
-          role: 'assistant',
+          role: 'model',
         },
       });
     }.bind(this)();

--- a/src/intelligence/intelligence.service.ts
+++ b/src/intelligence/intelligence.service.ts
@@ -342,7 +342,7 @@ Example Matching:
       message: msg.content,
     }));
 
-    this.prisma.aIThreadMessage.create({
+    await this.prisma.aIThreadMessage.create({
       data: {
         chatId: chatId,
         content: message,
@@ -374,7 +374,7 @@ Example Matching:
       userChatHistory,
     );
 
-    this.prisma.aIThreadMessage.create({
+    await this.prisma.aIThreadMessage.create({
       data: {
         chatId: chatId,
         content: result.content,

--- a/src/intelligence/intelligence.service.ts
+++ b/src/intelligence/intelligence.service.ts
@@ -696,11 +696,9 @@ Example Matching:
         - Cite sources when using external information
 
         Output Format Rules:
-        - Return structure: {"content": "markdown_formatted_response"}
+        - Return ALWAYS IN MARKDOWN
 
         Strict Requirements:
-        - Generate valid JSON with "content" field
-        - Ensure proper character escaping
         - Use complete Markdown syntax (no placeholders)
         - Balance original response with external content
         - Maintain natural, conversational tone

--- a/src/intelligence/intelligence.service.ts
+++ b/src/intelligence/intelligence.service.ts
@@ -368,10 +368,10 @@ Example Matching:
       ? model
       : AIModels.GeminiFast;
 
-    const result = await this.aiWrapper.generateContent(
+    const result = await this.aiWrapper.generateContentHistory(
       selectedModel,
       generatedPrompt,
-      // userChatHistory,
+      userChatHistory,
     );
 
     this.prisma.aIThreadMessage.create({


### PR DESCRIPTION
## Summary by Sourcery

Use the `generateContentHistory` method in the `intelligence.service.ts` file to include user chat history when generating content.