### PR TITLE
Add DeepseekR1Zero and QwQ_32_B models

### DIFF
--- a/src/intelligence/ai-wrapper.constants.ts
+++ b/src/intelligence/ai-wrapper.constants.ts
@@ -72,6 +72,7 @@ export const MODEL_PROVIDER_MAPPING: Record<AIModels, AIProvider> = {
   // OpenRouter Models
   [AIModels.DeepseekV3]: AI_PROVIDERS.OPENROUTER,
   [AIModels.DeepseekR1]: AI_PROVIDERS.OPENROUTER,
+  [AIModels.DeepseekR1Zero]: AI_PROVIDERS.OPENROUTER,
   [AIModels.DeepseekR1DistilledLlama]: AI_PROVIDERS.OPENROUTER,
   [AIModels.Qwen2_5VL72B]: AI_PROVIDERS.OPENROUTER,
 
@@ -87,6 +88,7 @@ export const MODEL_PROVIDER_MAPPING: Record<AIModels, AIProvider> = {
   [AIModels.Llama_3_1_9B]: AI_PROVIDERS.GROQ,
   [AIModels.Llama_3_70B]: AI_PROVIDERS.GROQ,
   [AIModels.Gemma_2_9B]: AI_PROVIDERS.GROQ,
+  [AIModels.QwQ_32_B]: AI_PROVIDERS.GROQ,
 
   // Anthropic Models
   [AIModels.Claude37Sonnet]: AI_PROVIDERS.ANTHROPIC,

--- a/src/intelligence/enums/models.enum.ts
+++ b/src/intelligence/enums/models.enum.ts
@@ -19,6 +19,7 @@ export enum AIModels {
   // OpenRouter Models
   DeepseekV3 = 'deepseek/deepseek-chat:free',
   DeepseekR1 = 'deepseek/deepseek-r1:free',
+  DeepseekR1Zero = 'deepseek/deepseek-r1-zero:free',
   DeepseekR1DistilledLlama = 'deepseek/deepseek-r1-distill-llama-70b:free',
   Qwen2_5VL72B = 'qwen/qwen2.5-vl-72b-instruct:free',
 
@@ -34,6 +35,7 @@ export enum AIModels {
   Llama_3_1_9B = 'llama-3.1-8b-instant',
   Llama_3_70B = 'llama3-70b-8192',
   Gemma_2_9B = 'gemma2-9b-it',
+  QwQ_32_B = 'qwen-qwq-32b',
 
   // Anthropic Models
   Claude37Sonnet = 'claude-3-7-sonnet-20250219',


### PR DESCRIPTION
## Summary by Sourcery

Adds the DeepseekR1Zero and QwQ_32_B models to the application, including their respective providers.

New Features:
- Adds support for the DeepseekR1Zero model via OpenRouter.
- Adds support for the QwQ_32_B model via Groq.