### PR TITLE
feat: update AI model references to use OptimusAlpha and Llama_4_Scout

### DIFF
--- a/src/intelligence/ai-wrapper.constants.ts
+++ b/src/intelligence/ai-wrapper.constants.ts
@@ -83,8 +83,7 @@ export const MODEL_PROVIDER_MAPPING: Record<AIModels, AIProvider> = {
   [AIModels.Reka_Flash_3]: AI_PROVIDERS.OPENROUTER,
   [AIModels.Llama_3_1_Neutron_Nvidia]: AI_PROVIDERS.OPENROUTER,
   [AIModels.DeepseekV3_0324]: AI_PROVIDERS.OPENROUTER,
-  [AIModels.QuasarAlpha]: AI_PROVIDERS.OPENROUTER,
-  [AIModels.Llama_4_Maverick_Open]: AI_PROVIDERS.OPENROUTER,
+  [AIModels.OptimusAlpha]: AI_PROVIDERS.OPENROUTER,
   [AIModels.Gemini2_5_Pro_Open]: AI_PROVIDERS.OPENROUTER,
   [AIModels.GeminiBetter]: AI_PROVIDERS.OPENROUTER,
 
@@ -104,7 +103,7 @@ export const MODEL_PROVIDER_MAPPING: Record<AIModels, AIProvider> = {
   [AIModels.Gemma_2_9B]: AI_PROVIDERS.GROQ,
   [AIModels.QwQ_32_B]: AI_PROVIDERS.GROQ,
   [AIModels.Llama_4_Scout]: AI_PROVIDERS.GROQ,
-  // [AIModels.Llama_4_Maverick]: AI_PROVIDERS.GROQ,
+  [AIModels.Llama_4_Maverick]: AI_PROVIDERS.GROQ,
 
   // Anthropic Models
   [AIModels.Claude37Sonnet]: AI_PROVIDERS.ANTHROPIC,

--- a/src/intelligence/enums/models.enum.ts
+++ b/src/intelligence/enums/models.enum.ts
@@ -4,11 +4,9 @@ export enum AIModels {
   GeminiFast = 'gemini-2.0-flash-lite-preview-02-05',
   GeminiFastCheap = 'gemini-1.5-flash',
   GeminiFastCheapSmall = 'gemini-1.5-flash-8b',
-  // GeminiBetter = 'gemini-2.0-flash-exp',
   GeminiAdvanced = 'gemini-2.0-flash-thinking-exp-01-21',
   GeminiTask = 'learnlm-1.5-pro-experimental',
   GeminiPro = 'gemini-2.0-pro-exp-02-05',
-  // Gemini2_5_Pro = 'gemini-2.5-pro-exp-03-25',
 
   // OpenAI Models
   GPT4OMini = 'gpt-4o-mini-2024-07-18',
@@ -30,8 +28,7 @@ export enum AIModels {
   Gemma_3_27B = 'google/gemma-3-27b-it:free',
   Reka_Flash_3 = 'rekaai/reka-flash-3:free',
   Llama_3_1_Neutron_Nvidia = 'nvidia/llama-3.1-nemotron-70b-instruct:free',
-  QuasarAlpha = 'openrouter/quasar-alpha',
-  Llama_4_Maverick_Open = 'meta-llama/llama-4-maverick:free',
+  OptimusAlpha = 'openrouter/optimus-alpha',
   Gemini2_5_Pro_Open = 'google/gemini-2.5-pro-exp-03-25:free',
   GeminiBetter = 'google/gemini-2.0-flash-exp:free',
 
@@ -51,7 +48,7 @@ export enum AIModels {
   Gemma_2_9B = 'gemma2-9b-it',
   QwQ_32_B = 'qwen-qwq-32b',
   Llama_4_Scout = 'meta-llama/llama-4-scout-17b-16e-instruct',
-  // Llama_4_Maverick = 'meta-llama/llama-4-maverick-17b-128e-instruct',
+  Llama_4_Maverick = 'meta-llama/llama-4-maverick-17b-128e-instruct',
 
   // Anthropic Models
   Claude37Sonnet = 'claude-3-7-sonnet-20250219',

--- a/src/intelligence/intelligence.service.ts
+++ b/src/intelligence/intelligence.service.ts
@@ -659,7 +659,7 @@ Example Matching:
 
     try {
       const result = await this.aiWrapper.generateContent(
-        AIModels.QuasarAlpha,
+        AIModels.Llama_4_Scout,
         prompt,
       );
 
@@ -1323,7 +1323,7 @@ Always consider the full conversation context and chat history to accurately cap
     User Message: "${message}"`;
 
     const aiResult = await this.aiWrapper.generateContent(
-      AIModels.QuasarAlpha,
+      AIModels.Llama_4_Scout,
       prompt,
     );
 
@@ -3188,7 +3188,7 @@ INSTRUCTIONS:
     let attempt = 1;
     const maxAttempts = 3;
     // Use the provided model or fall back to Gemini
-    const selectedModel = model || AIModels.QuasarAlpha;
+    const selectedModel = model || AIModels.OptimusAlpha;
 
     while (attempt <= maxAttempts) {
       try {


### PR DESCRIPTION
## Summary by Sourcery

Update AI model references to replace QuasarAlpha with OptimusAlpha and modify Llama model selections

New Features:
- Replace QuasarAlpha model with OptimusAlpha in AI model references

Enhancements:
- Update AI model configurations to use Llama_4_Scout as a default fallback model
- Uncomment and include Llama_4_Maverick model in available models